### PR TITLE
Added two separate banner for light/dark modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-![](https://assets.vercel.com/image/upload/v1549723846/repositories/hyper/hyper-3-repo-banner.png)
+![hyper-3-repo-banner](https://user-images.githubusercontent.com/73779089/181276460-9c2d1903-e79f-46ec-b446-e237a55f229a.png#gh-light-mode-only)
+
+ 
+ 
+  <div align="center">
+      <img src="https://user-images.githubusercontent.com/73779089/181276180-e04ca34b-80b4-45cf-b95a-3d110664528d.png#gh-dark-mode-only">
+  </div>
 
 <p align="center">
   <a aria-label="Vercel logo" href="https://vercel.com">


### PR DESCRIPTION
<!-- Hi there! Thanks for submitting a PR! We're excited to see what you've got for us.

- To help whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
If there's anything left to do and if there are any related PRs
- It'd also be extremely helpful to enable us to update your PR incase we need to rebase or what-not by checking `Allow edits from maintainers`
- If your PR changes some API, please make a PR for hyper website too: https://github.com/vercel/hyper-site.

Thanks, again! -->

This PR closes issue #6656

Just added an additional image to be used for dark mode.

NOTE: The additional banner used should be temporary as it's not the exact image that was used previously 

<img width="1236" alt="Screen Shot 2022-07-27 at 5 50 52 PM" src="https://user-images.githubusercontent.com/73779089/181281524-8262f282-17f1-4063-8806-7b9b5e7905c1.png">

<img width="1186" alt="Screen Shot 2022-07-27 at 5 42 39 PM" src="https://user-images.githubusercontent.com/73779089/181281674-37578b17-3ff8-4283-875d-85d2286fe1e3.png">



